### PR TITLE
Fix within-request SID collapse from wrong-level top-k and staging ra…

### DIFF
--- a/python/flashrec/attention/flashinfer.py
+++ b/python/flashrec/attention/flashinfer.py
@@ -265,6 +265,9 @@ class AttentionBackend:
         n = int(batch.n_rows)
         host_indptr, last_cpu, seq = self._pin.grow(n)
         sl_cpu = batch.seq_lens_cpu.view(-1)[:n]
+        # host_indptr must match the GPU seq_lens used for indptr. A racing
+        # non_blocking D2H here (stale lengths after a prompt-len change)
+        # makes CUDA-graph decode collapse; callers fill seq_lens_cpu on CPU.
         if sl_cpu.device.type == "cpu" and sl_cpu.dtype == torch.int32:
             seq.copy_(sl_cpu)
         else:

--- a/python/flashrec/config.py
+++ b/python/flashrec/config.py
@@ -141,6 +141,11 @@ class BeamRecConfig:
     enable_radix: bool = True
     enable_cuda_graph: bool = True
     enable_restricted_lm_head: bool = True
+    # Score only the active codebook at each SID depth. Without this, top-k
+    # over the full restricted head is often filled by wrong-level tokens;
+    # after the trie mask too few valid survivors remain and beams collapse
+    # into duplicate SIDs within one request.
+    enable_per_codebook_lm_head: bool = True
     enable_fused_expand: bool = True
     enable_graph_expand: bool = True
     enable_prefill_batch: bool = True

--- a/python/flashrec/engine/engine.py
+++ b/python/flashrec/engine/engine.py
@@ -170,6 +170,21 @@ class ModelEngine:
             self.lm_head.bind(self.model.lm_head())
         except Exception:
             logger.debug("restricted lm_head bind deferred", exc_info=True)
+        self._per_codebook = bool(getattr(config, "enable_per_codebook_lm_head", True))
+        if self._per_codebook:
+            cb = config.parsed_codebook_sizes()
+            if cb and self.lm_head.ready:
+                self.lm_head.bind_codebook(cb)
+                if self.lm_head.per_codebook_ready:
+                    logger.info(
+                        "per-codebook lm_head: levels=%d max_k=%d",
+                        self.lm_head.num_levels,
+                        self.lm_head.max_codebook_k,
+                    )
+                else:
+                    self._per_codebook = False
+            else:
+                self._per_codebook = False
         self.graph: Optional[DecodeGraphRunner] = None
         self._graph_ready = False
         self.profiler = None
@@ -321,7 +336,10 @@ class ModelEngine:
         )
         logits_fn = None
         logprobs_k = None
-        if self.lm_head.enabled:
+        # Per-codebook decode scores each SID level separately after the model
+        # forward; embedding a full-vocab lm_head into the CUDA graph would
+        # bypass that and reintroduce within-request SID collapse.
+        if self.lm_head.enabled and not self._per_codebook:
             try:
                 self.lm_head.bind(self.model.lm_head())
             except Exception:
@@ -391,8 +409,17 @@ class ModelEngine:
                     else:
                         hidden = self.model(batch)
                 last = self.last_token_hidden(hidden, batch)
+                if self._per_codebook and not batch.is_prefill:
+                    return last, None, None
                 logprobs, cands = self.lm_head.compute(last, self.model.lm_head())
                 return logprobs, cands, None
         finally:
             if self.profiler is not None:
                 self.profiler.after_forward(is_prefill=bool(batch.is_prefill))
+
+    def lm_head_level(
+        self, hidden: torch.Tensor, level: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Per-codebook logprobs for a single decode level."""
+        with torch.inference_mode():
+            return self.lm_head.compute_level(hidden, level)

--- a/python/flashrec/engine/graph.py
+++ b/python/flashrec/engine/graph.py
@@ -452,6 +452,7 @@ class DecodeGraphRunner:
             )
             sl_cpu = batch.seq_lens_cpu.view(-1)[:raw_bs]
             if sl_cpu.device.type != "cpu":
+                # Blocking D2H: FlashInfer plan() reads seq_lens_cpu immediately.
                 sl_cpu = sl_cpu.detach().to("cpu")
             # copy_ converts dtype in place; an explicit .to() would allocate
             # a CPU temp per step whenever the producer dtype differs.

--- a/python/flashrec/engine/staging.py
+++ b/python/flashrec/engine/staging.py
@@ -7,6 +7,20 @@ from typing import Dict, Optional, Sequence
 import torch
 
 
+def fill_cpu_seq_lens(dest: torch.Tensor, base: torch.Tensor, step: int) -> None:
+    """Write ``base + step + 1`` into a CPU seq_lens buffer (no D2H).
+
+    FlashInfer ``plan()`` builds host_indptr from this tensor immediately.
+    A non_blocking GPU→CPU copy of seq_lens races: after a prompt-len change
+    the CPU buffer still holds the previous wave, and CUDA-graph decode
+    collapses beams onto one SID.
+    """
+    n = int(dest.numel())
+    if n <= 0:
+        return
+    torch.add(base.view(-1)[:n], int(step) + 1, out=dest.view(-1)[:n])
+
+
 def _fill_pinned(pin: torch.Tensor, values: Sequence[int], dtype: torch.dtype) -> None:
     """Write ints into an existing pinned CPU slice without allocating a tensor."""
     n = int(pin.numel())
@@ -20,11 +34,20 @@ def _fill_pinned(pin: torch.Tensor, values: Sequence[int], dtype: torch.dtype) -
 
 
 class PinnedStage:
-    """Grow-only pinned CPU buffers plus optional GPU mirrors."""
+    """Grow-only pinned CPU buffers plus optional GPU mirrors.
+
+    ``copy_list`` ping-pongs two pinned slots per name and waits for the prior
+    H2D that sourced from a slot before CPU-refilling it. Overwriting a pin
+    while a non_blocking H2D still reads it feeds stale ints to the GPU (fused
+    expand then writes the next SID token into the wrong column, leaving a
+    literal ``0`` / ``!`` in the middle of the SID).
+    """
 
     def __init__(self) -> None:
         self._cpu: Dict[str, torch.Tensor] = {}
         self._gpu: Dict[str, torch.Tensor] = {}
+        self._pin_epoch: Dict[str, int] = {}
+        self._pin_ready: Dict[str, Optional[torch.cuda.Event]] = {}
 
     def cpu(self, name: str, n: int, dtype: torch.dtype) -> torch.Tensor:
         n = max(int(n), 0)
@@ -64,7 +87,15 @@ class PinnedStage:
             if n:
                 _fill_pinned(dest, values, dtype)
             return dest, dest
-        pin = self.cpu(name, n, dtype)
+        epoch = int(self._pin_epoch.get(name, 0))
+        self._pin_epoch[name] = epoch + 1
+        pin_key = f"{name}#pin{epoch & 1}"
+        pin = self.cpu(pin_key, n, dtype)
+        # CPU must not refill this slot until the previous H2D that read it
+        # has completed; otherwise the in-flight DMA observes the new values.
+        prev = self._pin_ready.get(pin_key)
+        if prev is not None:
+            prev.synchronize()
         if n:
             _fill_pinned(pin, values, dtype)
         if dest is None:
@@ -73,6 +104,10 @@ class PinnedStage:
             dest = dest.view(-1)[:n]
         if n:
             dest.copy_(pin, non_blocking=True)
+            if device.type == "cuda" and torch.cuda.is_available():
+                ev = torch.cuda.Event()
+                ev.record()
+                self._pin_ready[pin_key] = ev
         return dest, pin
 
     def copy_rows(
@@ -124,7 +159,13 @@ class PinnedStage:
         if not gpu_parts:
             return
         total = int(sum(len(v) for v, _ in gpu_parts))
-        pin = self.cpu(name, total, dtype)
+        epoch = int(self._pin_epoch.get(name, 0))
+        self._pin_epoch[name] = epoch + 1
+        pin_key = f"{name}#pin{epoch & 1}"
+        pin = self.cpu(pin_key, total, dtype)
+        prev = self._pin_ready.get(pin_key)
+        if prev is not None:
+            prev.synchronize()
         off = 0
         for values, _dest in gpu_parts:
             n = len(values)
@@ -134,6 +175,10 @@ class PinnedStage:
         gpu = self.gpu(name, total, dtype, device)
         if total:
             gpu.copy_(pin, non_blocking=True)
+            if device.type == "cuda" and torch.cuda.is_available():
+                ev = torch.cuda.Event()
+                ev.record()
+                self._pin_ready[pin_key] = ev
         off = 0
         for values, dest in gpu_parts:
             n = len(values)

--- a/python/flashrec/logits.py
+++ b/python/flashrec/logits.py
@@ -18,6 +18,9 @@ class RestrictedLMHead:
         self.enabled = bool(enabled and self.ids)
         self._token_ids: Optional[torch.Tensor] = None
         self._weight: Optional[torch.Tensor] = None
+        self._level_weights: Optional[List[torch.Tensor]] = None
+        self._level_token_ids: Optional[List[torch.Tensor]] = None
+        self._codebook_sizes: Optional[List[int]] = None
 
     @property
     def token_ids(self) -> Optional[torch.Tensor]:
@@ -35,11 +38,56 @@ class RestrictedLMHead:
             self.enabled and self._weight is not None and self._token_ids is not None
         )
 
+    @property
+    def per_codebook_ready(self) -> bool:
+        return bool(self._level_weights is not None and len(self._level_weights) > 0)
+
+    @property
+    def num_levels(self) -> int:
+        return len(self._level_weights) if self._level_weights else 0
+
+    @property
+    def max_codebook_k(self) -> int:
+        if not self._codebook_sizes:
+            return 0
+        return max(self._codebook_sizes)
+
+    def codebook_k(self, level: int) -> int:
+        if not self._codebook_sizes or level < 0 or level >= len(self._codebook_sizes):
+            return 0
+        return self._codebook_sizes[level]
+
     def bind(self, lm_weight: torch.Tensor) -> None:
         """Slice restricted rows once after weight load."""
         if lm_weight is None:
             return
         self._ensure(lm_weight.device, lm_weight)
+
+    def bind_codebook(self, codebook_sizes: List[int]) -> None:
+        """Pre-slice per-level weight views from the already-bound ``_weight``.
+
+        Each level's weight is a zero-copy ``narrow()`` view. Must be called
+        after ``bind()``.
+        """
+        if self._weight is None or not self.enabled:
+            return
+        total = sum(codebook_sizes)
+        if total != self._weight.shape[0]:
+            return
+        self._codebook_sizes = list(codebook_sizes)
+        self._level_weights = []
+        self._level_token_ids = []
+        offset = 0
+        ids = self.ids or []
+        device = self._weight.device
+        for size in codebook_sizes:
+            self._level_weights.append(self._weight.narrow(0, offset, size))
+            self._level_token_ids.append(
+                torch.tensor(
+                    ids[offset : offset + size], dtype=torch.long, device=device
+                )
+            )
+            offset += size
 
     def _ensure(self, device: torch.device, lm_weight: torch.Tensor) -> None:
         if not self.enabled:
@@ -70,6 +118,24 @@ class RestrictedLMHead:
     def _restricted_logprobs(self, hidden: torch.Tensor) -> torch.Tensor:
         logits = F.linear(hidden.to(dtype=self._weight.dtype), self._weight)
         return F.log_softmax(logits.float(), dim=-1)
+
+    def compute_level(
+        self, hidden: torch.Tensor, level: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Per-codebook logprobs: GEMM only against level's weight slice."""
+        weights = self._level_weights
+        ids = self._level_token_ids
+        if weights is None or ids is None or level < 0 or level >= len(weights):
+            # Past last codebook (max_tokens > SID depth): full restricted head.
+            if self._weight is None or self._token_ids is None:
+                raise RuntimeError(
+                    "RestrictedLMHead.compute_level requires bind_codebook()"
+                )
+            return self._restricted_logprobs(hidden), self._token_ids
+        w = weights[level]
+        logits = F.linear(hidden.to(dtype=w.dtype), w)
+        logprobs = F.log_softmax(logits.float(), dim=-1)
+        return logprobs, ids[level]
 
     def compute_into(
         self,

--- a/python/flashrec/scheduler/scheduler.py
+++ b/python/flashrec/scheduler/scheduler.py
@@ -20,7 +20,7 @@ from flashrec.core import (
 )
 from flashrec.engine.engine import ModelEngine
 from flashrec.engine.graph import ExpandCaptureSpec
-from flashrec.engine.staging import PinnedStage
+from flashrec.engine.staging import PinnedStage, fill_cpu_seq_lens
 from flashrec.hostpool import HostPool
 from flashrec.kernel.beam_trie import (
     GenrecFusedResult,
@@ -41,6 +41,7 @@ from flashrec.search.expand import (
     expand_step,
     init_from_prefill,
     init_from_prefill_batch,
+    narrow_to_codebook_level,
 )
 from flashrec.search.score import beam_score
 from flashrec.search.trie import build_beam_valid_path
@@ -91,6 +92,7 @@ class BeamRecEngine:
         self._last_prefill_ev = None
         self._wave_pool_rows: Optional[torch.Tensor] = None
         self._wave_seq_base: Optional[torch.Tensor] = None
+        self._wave_seq_base_cpu: Optional[torch.Tensor] = None
         self._wave_seq_base_sum: int = 0
         self._wave_reqs_key: Optional[tuple] = None
         self._wave_n_rows: int = 0
@@ -929,6 +931,10 @@ class BeamRecEngine:
             )
         return out
 
+    def _codebook_sizes(self) -> Optional[List[int]]:
+        sizes = self.config.parsed_codebook_sizes()
+        return list(sizes) if sizes else None
+
     def _init_wave_precompute(
         self,
         prepared: List[tuple],
@@ -961,6 +967,11 @@ class BeamRecEngine:
                 or limit <= 1
             ):
                 return None
+        # Prefill seeds beam 0 from codebook 0 only — same collapse hazard as
+        # decode when wrong-level tokens dominate a full-vocab top-k.
+        logprobs, cand_ids = narrow_to_codebook_level(
+            logprobs, cand_ids, self._codebook_sizes(), level=0
+        )
         bls = init_from_prefill_batch(
             logprobs,
             beam_width=bw,
@@ -1027,6 +1038,9 @@ class BeamRecEngine:
             req.expanded = True
             return
         limit = self.generation_token_limit(req.max_new_tokens)
+        logprobs, cand_ids = narrow_to_codebook_level(
+            logprobs, cand_ids, self._codebook_sizes(), level=0
+        )
         req.beam_list = init_from_prefill(
             logprobs,
             beam_width=req.beam_width,
@@ -1063,11 +1077,21 @@ class BeamRecEngine:
         logprobs: torch.Tensor,
         cand_ids: Optional[torch.Tensor],
     ) -> None:
+        per_cb = cand_ids is None and getattr(self.runner, "_per_codebook", False)
+        cb_sizes = None if per_cb else self._codebook_sizes()
         offset = 0
         for group in groups:
             n_rows = sum(int(r.beam_width) for r in group)
             sl = logprobs[offset : offset + n_rows]
-            self._expand_decode(group, sl, cand_ids)
+            bl = group[0].beam_list if group else None
+            level = int(bl.generated_len()) if bl is not None else 0
+            if per_cb:
+                lp, cids = self.runner.lm_head_level(sl, level)
+            else:
+                # Full restricted head fallback: narrow to the active codebook
+                # before top-k so wrong-level tokens cannot starve the pool.
+                lp, cids = narrow_to_codebook_level(sl, cand_ids, cb_sizes, level)
+            self._expand_decode(group, lp, cids)
             offset += n_rows
 
     def _ordered_live(
@@ -1259,11 +1283,12 @@ class BeamRecEngine:
             seq_base: List[int] = []
             for req in reqs:
                 seq_base.extend([int(req.seq_len)] * int(req.beam_width))
-            seq_base_gpu, _ = self._stage.copy_list(
+            seq_base_gpu, seq_base_cpu = self._stage.copy_list(
                 "_wave_base", seq_base, device, torch.int64
             )
             self._wave_pool_rows = pool_rows
             self._wave_seq_base = seq_base_gpu
+            self._wave_seq_base_cpu = seq_base_cpu
             self._wave_seq_base_sum = int(sum(seq_base))
             self._wave_reqs_key = reqs_key
             self._wave_n_rows = n_rows
@@ -1321,8 +1346,12 @@ class BeamRecEngine:
                 torch.add(
                     self._wave_seq_base[:raw], step + 1, out=buf["seq_lens"][:raw]
                 )
-                buf["seq_lens_cpu"][:raw].copy_(
-                    buf["seq_lens"][:raw], non_blocking=True
+                # CPU seq_lens for FlashInfer plan must not D2H the GPU write:
+                # plan() reads host_indptr immediately, and a stale copy after a
+                # prompt-len change collapses CUDA-graph decode.
+                assert self._wave_seq_base_cpu is not None
+                fill_cpu_seq_lens(
+                    buf["seq_lens_cpu"][:raw], self._wave_seq_base_cpu[:raw], step
                 )
                 seq_after_total = self._wave_seq_base_sum + raw * (step + 1)
                 with trace_range(f"flashrec.gather_kv rows={raw}"):
@@ -1485,6 +1514,8 @@ class BeamRecEngine:
         # Pinned staging: torch.tensor(list, device=cuda) is a pageable H2D
         # that stalls the host behind the in-flight forward on the expand
         # stream (the graph path already stages "exp_col" the same way).
+        # PinnedStage ping-pongs pins so a later fill cannot corrupt an
+        # in-flight non_blocking H2D (that bug wrote SID column 1 as 0).
         if self.device.type == "cuda":
             col_t, _ = self._stage.copy_list(
                 "exp_col_eager", cols, self.device, torch.int32

--- a/python/flashrec/search/expand.py
+++ b/python/flashrec/search/expand.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -19,7 +19,43 @@ __all__ = [
     "expand_step",
     "apply_temperature",
     "gumbel_like",
+    "narrow_to_codebook_level",
 ]
+
+
+def narrow_to_codebook_level(
+    logprobs: torch.Tensor,
+    cand_ids: Optional[torch.Tensor],
+    codebook_sizes: Optional[Sequence[int]],
+    level: int,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Restrict full restricted-head outputs to one codebook before top-k.
+
+    Expand previously took ``beam_candidates`` from *all* codebook tokens, then
+    applied the trie mask. Wrong-level mass often filled that pool, so after
+    masking too few valid survivors remained and beams collapsed onto duplicate
+    SIDs. Narrowing first keeps every top-k slot inside the active level.
+
+    Ranking within a level is unchanged vs slicing a full-vocab log_softmax
+    (the discarded mass is a per-row constant). No-ops when ``logprobs`` is
+    already per-level width, or when sizes / level are missing.
+    """
+    if (
+        codebook_sizes is None
+        or cand_ids is None
+        or not isinstance(cand_ids, torch.Tensor)
+        or level < 0
+        or level >= len(codebook_sizes)
+    ):
+        return logprobs, cand_ids
+    sizes = [int(s) for s in codebook_sizes]
+    total = sum(sizes)
+    width = int(logprobs.shape[-1])
+    if width != total or int(cand_ids.numel()) != total:
+        return logprobs, cand_ids
+    offset = sum(sizes[:level])
+    k = sizes[level]
+    return logprobs[..., offset : offset + k], cand_ids[offset : offset + k]
 
 
 def apply_temperature(logprobs: torch.Tensor, temperature: float) -> torch.Tensor:

--- a/tests/test_beam_search_diff.py
+++ b/tests/test_beam_search_diff.py
@@ -27,7 +27,8 @@ Usage::
 Optional env:
   FLASHREC_DIFF_MODEL    model dir (required; test skips when unset)
   FLASHREC_DIFF_PROMPT   user text for chat template (default: short GenRec-like prompt)
-  FLASHREC_DIFF_CATALOG  sid-vocab JSON; omit for codebook-only (not trie) constraint
+  FLASHREC_DIFF_CATALOG  sid-vocab JSON; when set, both FlashRec and HF apply
+                         codebook + trie (omit for codebook-only)
   FLASHREC_DIFF_QUANT    ``fp8`` (default, production path) or ``bf16`` (tighter HF match)
   FLASHREC_DIFF_BEAMS    comma-separated beam widths (default ``4,8``)
 """
@@ -46,6 +47,7 @@ from flashrec.config import BeamRecConfig, parse_int_list
 from flashrec.core import ForwardBatch
 from flashrec.engine.engine import ModelEngine
 from flashrec.scheduler.scheduler import BeamRecEngine
+from flashrec.search.trie import BeamValidPathTrie, build_beam_valid_path
 from flashrec.sid_layout import infer_sid_layout
 
 _DEFAULT_PROMPT = "predict next: <|sid_begin|><s_a_0><s_b_0><s_c_0><|sid_end|>"
@@ -63,9 +65,13 @@ def _resolve_model_path() -> Optional[str]:
     return str(path)
 
 
+def _catalog_path() -> Optional[str]:
+    raw = os.environ.get("FLASHREC_DIFF_CATALOG", "").strip()
+    return raw or None
+
+
 def _sid_layout_for(model_path: str):
-    catalog = os.environ.get("FLASHREC_DIFF_CATALOG", "").strip() or None
-    return infer_sid_layout(model_path, catalog)
+    return infer_sid_layout(model_path, _catalog_path())
 
 
 def _quantization() -> str:
@@ -229,10 +235,12 @@ class _BeamDiffState:
         self._cached_flashrec = None
         self._cached_tok = None
         self._cached_masks = None
+        self._cached_trie = None
+        catalog = _catalog_path()
         print(
             f"\nSID layout {layout.token_range}/{layout.codebook_sizes} "
             f"boundary {layout.boundary_tokens} quant={self.quantization} "
-            f"beams={self.beam_widths}"
+            f"beams={self.beam_widths} catalog={catalog or '(codebook-only)'}"
         )
 
     def release(self):
@@ -240,6 +248,7 @@ class _BeamDiffState:
         self._cached_flashrec = None
         self._cached_tok = None
         self._cached_masks = None
+        self._cached_trie = None
         torch.cuda.empty_cache()
 
 
@@ -304,8 +313,7 @@ def _flashrec_engine(state: _BeamDiffState) -> BeamRecEngine:
                 sid_token_range=state.sid_token_range,
                 sid_codebook_sizes=state.codebook_sizes_s,
                 sid_boundary_tokens=state.boundary_s,
-                sid_vocab_file=os.environ.get("FLASHREC_DIFF_CATALOG", "").strip()
-                or None,
+                sid_vocab_file=_catalog_path(),
                 beam_width=max_n,
                 max_tokens=state.depth + 2,
                 length_penalty=1.0,
@@ -338,6 +346,52 @@ def _codebook_masks(state: _BeamDiffState, vocab_size: int) -> List[torch.Tensor
     return masks
 
 
+def _valid_path(state: _BeamDiffState) -> BeamValidPathTrie:
+    if state._cached_trie is not None:
+        return state._cached_trie
+    catalog = _catalog_path()
+    if not catalog:
+        state._cached_trie = BeamValidPathTrie(mode="none")
+        return state._cached_trie
+    trie = build_beam_valid_path(
+        sid_file=catalog,
+        codebook_sizes=state.codebook_sizes,
+        special_token_ids=state.special_ids,
+    )
+    print(
+        f"valid_path mode={trie.mode} depth={trie.max_depth} file={catalog}",
+        flush=True,
+    )
+    state._cached_trie = trie
+    return trie
+
+
+def _apply_trie_mask(
+    trie: BeamValidPathTrie,
+    input_ids_t: torch.Tensor,
+    scores: torch.Tensor,
+    prompt_len: int,
+    step: int,
+) -> torch.Tensor:
+    """Mask tokens that do not continue a valid SID prefix (same as FlashRec)."""
+    if trie.mode != "trie":
+        return scores
+    neg = torch.finfo(scores.dtype).min
+    scores = scores.clone()
+    for i in range(int(input_ids_t.shape[0])):
+        prefix = input_ids_t[i, prompt_len : prompt_len + step].tolist()
+        allowed = trie.allowed_next(prefix)
+        if allowed is None:
+            continue
+        if not allowed:
+            scores[i].fill_(neg)
+            continue
+        keep = torch.zeros(scores.shape[-1], dtype=torch.bool, device=scores.device)
+        keep[torch.tensor(list(allowed), dtype=torch.long, device=scores.device)] = True
+        scores[i] = torch.where(keep, scores[i], torch.full_like(scores[i], neg))
+    return scores
+
+
 def _get_transformers_beam_sequences(
     state: _BeamDiffState, input_ids: List[int], beam_width: int
 ) -> List[str]:
@@ -348,12 +402,14 @@ def _get_transformers_beam_sequences(
     depth = state.depth
     pad_id = int(getattr(model.config, "eos_token_id", 0) or 0)
     masks = _codebook_masks(state, int(model.config.vocab_size))
+    trie = _valid_path(state)
 
     class _StepMask(LogitsProcessor):
         def __call__(self, input_ids_t: torch.Tensor, scores: torch.Tensor):
             step = int(input_ids_t.shape[-1]) - prompt_len
             if 0 <= step < depth:
-                return scores + masks[step]
+                scores = scores + masks[step]
+                return _apply_trie_mask(trie, input_ids_t, scores, prompt_len, step)
             scores = scores.clone()
             scores.fill_(torch.finfo(scores.dtype).min)
             scores[:, pad_id] = 0.0
@@ -430,7 +486,9 @@ def test_beam_search_different_widths(beam_diff_state: _BeamDiffState):
     hf_by_n = {}
     for beam_width in state.beam_widths:
         print(f"\n[HF] generating n={beam_width}", flush=True)
-        hf_by_n[beam_width] = _get_transformers_beam_sequences(input_ids, beam_width)
+        hf_by_n[beam_width] = _get_transformers_beam_sequences(
+            state, input_ids, beam_width
+        )
     state._cached_hf = None
     state._cached_masks = None
     torch.cuda.empty_cache()
@@ -438,7 +496,7 @@ def test_beam_search_different_widths(beam_diff_state: _BeamDiffState):
     mb_by_n = {}
     for beam_width in state.beam_widths:
         print(f"\n[flashrec] generating n={beam_width}", flush=True)
-        mb_by_n[beam_width] = _get_flashrec_beam_sequences(input_ids, beam_width)
+        mb_by_n[beam_width] = _get_flashrec_beam_sequences(state, input_ids, beam_width)
 
     print(f"\n{'n':>5}  {'overlap':>8}  {'top-1':>5}  {'|intersect|':>12}")
     for beam_width in state.beam_widths:
@@ -499,7 +557,7 @@ class _PrefillState:
         print(
             f"\nSID layout {layout.token_range}/{layout.codebook_sizes} "
             f"boundary {layout.boundary_tokens} quant={self.quantization} "
-            f"atol={self.max_abs_diff}"
+            f"atol={self.max_abs_diff} catalog={_catalog_path() or '(codebook-only)'}"
         )
 
 
@@ -534,7 +592,7 @@ def _build_runner(state: _PrefillState) -> ModelEngine:
         sid_token_range=state.sid_token_range,
         sid_codebook_sizes=state.codebook_sizes_s,
         sid_boundary_tokens=state.boundary_s,
-        sid_vocab_file=os.environ.get("FLASHREC_DIFF_CATALOG", "").strip() or None,
+        sid_vocab_file=_catalog_path(),
         enable_cuda_graph=False,
         enable_graph_expand=False,
         enable_radix=False,

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -6,6 +6,7 @@ from flashrec.search.expand import (
     init_from_prefill,
     init_from_prefill_batch,
     joint_select,
+    narrow_to_codebook_level,
 )
 from flashrec.search.score import beam_score
 from flashrec.search.trie import BeamValidPathTrie
@@ -423,3 +424,47 @@ class TestExpand:
         res = joint_select(cum, lp, toks, stop, beam_width=2)
         assert int(res.num_finished.item()) >= 1
         assert int(res.num_survivors.item()) >= 1
+
+
+class TestNarrowToCodebookLevel:
+    """Full-vocab top-k before trie mask collapses beams; narrow first fixes it."""
+
+    def test_narrow_slices_active_level(self):
+        sizes = [4, 4, 2]
+        cand = torch.arange(sum(sizes), dtype=torch.int64)
+        lp = torch.randn(3, sum(sizes))
+        out_lp, out_ids = narrow_to_codebook_level(lp, cand, sizes, level=1)
+        assert out_lp.shape == (3, 4)
+        assert out_ids.tolist() == [4, 5, 6, 7]
+        torch.testing.assert_close(out_lp, lp[:, 4:8])
+
+    def test_narrow_noop_when_already_per_level(self):
+        cand = torch.arange(8, dtype=torch.int64)
+        lp = torch.randn(2, 8)
+        out_lp, out_ids = narrow_to_codebook_level(lp, cand, [8, 8], level=0)
+        assert out_lp.data_ptr() == lp.data_ptr()
+        assert out_ids.data_ptr() == cand.data_ptr()
+
+    def test_wrong_level_topk_starves_without_narrow(self):
+        """Reproduce SID collapse: wrong-level mass fills top-k."""
+        sizes = [8, 8]
+        total = sum(sizes)
+        bw, cand_k = 4, 8  # beam_candidates = 2 * bw
+        # Level-0 tokens dominate; only 1 level-1 token is in the global top-k.
+        lp = torch.full((bw, total), -20.0)
+        lp[:, :8] = torch.linspace(-0.1, -0.8, 8).unsqueeze(0).expand(bw, -1)
+        lp[:, 8] = -1.0  # sole level-1 token that can enter top-k
+        lp[:, 9:12] = torch.linspace(-2.0, -4.0, 3).unsqueeze(0).expand(bw, -1)
+
+        vals, idx = torch.topk(lp, cand_k, dim=-1)
+        level1_in_pool = (idx >= 8).sum(dim=-1)
+        assert int(level1_in_pool.min()) <= 1
+
+        narrow_lp, narrow_ids = narrow_to_codebook_level(
+            lp, torch.arange(total), sizes, level=1
+        )
+        _nvals, nidx = torch.topk(narrow_lp, min(cand_k, narrow_lp.shape[-1]), dim=-1)
+        tokens = narrow_ids[nidx]
+        assert tokens.shape == (bw, 8)
+        assert bool((tokens >= 8).all())
+        assert int(tokens[0].unique().numel()) == 8

--- a/tests/test_kv_pool.py
+++ b/tests/test_kv_pool.py
@@ -38,6 +38,32 @@ class TestGatherAndPool:
         assert gpu.data_ptr() == dest[:3].data_ptr()
         assert pin.data_ptr() == dest[:3].data_ptr()
 
+    def test_copy_list_pin_reuse_survives_async_h2d(self):
+        """Refilling the pin before a prior H2D finishes must not corrupt GPU.
+
+        Fused expand stages per-step ``col`` through this path; without
+        ping-pong + wait, the next fill overwrites the in-flight DMA source and
+        the SID middle token is written into the wrong column (stays 0).
+        """
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA required")
+        from flashrec.engine.staging import PinnedStage
+
+        st = PinnedStage()
+        device = torch.device("cuda:0")
+        # Capture each transfer into its own dest so we can check after sync.
+        captured = []
+        for i in range(32):
+            dest = torch.empty(1, dtype=torch.int32, device=device)
+            st.copy_list("exp_col_eager", [i], device, torch.int32, dest=dest)
+            captured.append(dest)
+        torch.cuda.synchronize()
+        assert [int(t.item()) for t in captured] == list(range(32))
+        # Consecutive calls must alternate pin slots.
+        assert st._pin_epoch["exp_col_eager"] == 32
+        assert "exp_col_eager#pin0" in st._cpu
+        assert "exp_col_eager#pin1" in st._cpu
+
     def test_copy_rows_skips_cat(self):
         from flashrec.engine.staging import PinnedStage
 

--- a/tests/test_logits.py
+++ b/tests/test_logits.py
@@ -110,3 +110,70 @@ class TestRestrictedLMHeadCudaGraph:
             g.replay()
         torch.cuda.synchronize()
         torch.testing.assert_close(clone_a, eager_a[:2], atol=2e-3, rtol=2e-3)
+
+
+class TestPerCodebookLMHead:
+    """Per-codebook lm_head: bind_codebook, compute_level, numerical equivalence."""
+
+    def _make_head(self, vocab=24, hidden=8, codebook_sizes=None):
+        if codebook_sizes is None:
+            codebook_sizes = [8, 8, 8]
+        total = sum(codebook_sizes)
+        torch.manual_seed(42)
+        lm_weight = torch.randn(vocab, hidden)
+        ids = list(range(total))
+        head = RestrictedLMHead(ids, enabled=True)
+        head.bind(lm_weight)
+        head.bind_codebook(codebook_sizes)
+        return head, lm_weight, codebook_sizes
+
+    def test_bind_codebook_creates_level_weights(self):
+        head, _, cb = self._make_head()
+        assert head.per_codebook_ready
+        assert head.num_levels == 3
+        assert head.max_codebook_k == 8
+        for i, size in enumerate(cb):
+            assert head.codebook_k(i) == size
+
+    def test_compute_level_matches_full_compute_sliced(self):
+        head, lm_weight, cb = self._make_head()
+        torch.manual_seed(7)
+        hidden = torch.randn(5, 8)
+        full_lp, _ = head.compute(hidden, lm_weight)
+        offset = 0
+        for level, size in enumerate(cb):
+            level_lp, level_ids = head.compute_level(hidden, level)
+            assert level_lp.shape == (5, size)
+            assert level_ids.tolist() == list(range(offset, offset + size))
+            full_slice = full_lp[:, offset : offset + size]
+            full_order = full_slice.argsort(dim=-1, descending=True)
+            level_order = level_lp.argsort(dim=-1, descending=True)
+            assert torch.equal(full_order, level_order)
+            offset += size
+
+    def test_compute_level_log_softmax_sums_to_one(self):
+        head, _, cb = self._make_head()
+        torch.manual_seed(8)
+        hidden = torch.randn(3, 8)
+        for level in range(len(cb)):
+            lp, _ = head.compute_level(hidden, level)
+            probs = lp.exp().sum(dim=-1)
+            torch.testing.assert_close(probs, torch.ones(3), atol=1e-5, rtol=1e-5)
+
+    def test_small_last_codebook(self):
+        head, _, cb = self._make_head(vocab=26, hidden=8, codebook_sizes=[8, 8, 8, 2])
+        assert head.num_levels == 4
+        assert head.codebook_k(3) == 2
+        torch.manual_seed(9)
+        hidden = torch.randn(4, 8)
+        lp, ids = head.compute_level(hidden, 3)
+        assert lp.shape == (4, 2)
+        assert ids.tolist() == [24, 25]
+
+    def test_bind_codebook_mismatch_is_noop(self):
+        torch.manual_seed(0)
+        lm_weight = torch.randn(10, 4)
+        head = RestrictedLMHead(list(range(10)), enabled=True)
+        head.bind(lm_weight)
+        head.bind_codebook([5, 3])
+        assert not head.per_codebook_ready

--- a/tests/test_scheduler_opts.py
+++ b/tests/test_scheduler_opts.py
@@ -1,5 +1,8 @@
+import torch
+
 from flashrec.config import BeamRecConfig
 from flashrec.core import BeamResult, BeamSequence
+from flashrec.engine.staging import fill_cpu_seq_lens
 from flashrec.hostpool import HostPool
 from flashrec.scheduler.batching import (
     batch_wait_seconds,
@@ -730,3 +733,13 @@ class TestHostPool:
         pool.flush()
         assert seen == [7]
         pool.shutdown()
+
+
+class TestFillCpuSeqLens:
+    def test_overwrites_stale_short_wave(self):
+        dest = torch.tensor([3, 3, 3], dtype=torch.int64)
+        base = torch.tensor([100, 100, 80], dtype=torch.int64)
+        fill_cpu_seq_lens(dest, base, step=0)
+        assert dest.tolist() == [101, 101, 81]
+        fill_cpu_seq_lens(dest, base, step=2)
+        assert dest.tolist() == [103, 103, 83]


### PR DESCRIPTION
…ces.

Score each codebook level separately (or narrow before top-k), and keep CPU seq_lens / pinned H2D sources coherent so CUDA-graph decode no longer duplicates SIDs.

## Summary

<!-- 1-3 bullets: why this change exists, not a file list. -->

## Test plan

- [ ] `pre-commit run --all-files`
- [ ] `PYTHONPATH=python python -m unittest discover -s tests -v`
- [ ] New/changed CLI flags documented in `docs/configuration.md` and `docs/configuration.zh-CN.md`; HTTP fields in `docs/api.md`
- [ ] User-visible behaviour recorded under `Unreleased` in `CHANGELOG.md`

## Notes

<!-- CUDA-graph capture safety, SID layout (catalog + tokenizer inference), FP8 path, or anything a reviewer should try on GPU. -->
